### PR TITLE
Structured to automatically convert .py into .cwl

### DIFF
--- a/cwl/PythonConverter/mvl2hdf.py
+++ b/cwl/PythonConverter/mvl2hdf.py
@@ -1,0 +1,1 @@
+/home/sbrinckm/FZJ/SourceCode/ReverseFileFormat/Converters/mvl2hdf.py

--- a/cwl/PythonConverter/mvl2hdf.py
+++ b/cwl/PythonConverter/mvl2hdf.py
@@ -1,1 +1,101 @@
-/home/sbrinckm/FZJ/SourceCode/ReverseFileFormat/Converters/mvl2hdf.py
+#!/usr/bin/python3
+"""
+convert Doli .mvl to .hdf5 file (partial conversion of 15 metadata)
+
+in_file:
+  label: Doli binary file (.mvl) for tension-compression machine
+  vendor: Doli (www.doli.de)
+  software: Test&Motion (Software for Universal Test Machines for Windows) Version 4.1
+out_file:
+  label: custom HDF5 with k-series as well as metadata and converter groups
+"""
+import struct, sys, os, hashlib
+import h5py                                    #CWL requirement
+import numpy as np
+from datetime import datetime
+
+convURI = 'https://raw.githubusercontent.com/NFDI4Chem/formaTAPIRest/main/cwl/mvl2hdf.cwl'
+convVersion = '1.0'
+
+## COMMON PART FOR ALL CONVERTERS
+fileNameIn = sys.argv[1]
+fileNameOut= os.path.splitext(fileNameIn)[0]+'.hdf5'
+fIn   = open(fileNameIn,'br')
+fOut  = h5py.File(fileNameOut, 'w')
+metadata = fOut.create_group("metadata")
+converter = fOut.create_group("converter")
+converter.attrs['uri'] =     convURI
+converter.attrs['version'] = convVersion
+converter.attrs['original file name'] = fileNameIn
+md5Hash = hashlib.md5()
+md5Hash.update(fIn.read())
+converter.attrs['original md5-sum'] = md5Hash.hexdigest()
+
+def addAttrs(offset, format, hdfBranch, key):
+  # helper function: add attribute to branch
+  if type(key)==list:
+    fIn.seek(key[0])
+    key = bytearray(source=fIn.read(key[1])).decode('latin-1')
+    key = key.replace('\x00','')   # ValueError: VLEN strings do not support embedded NULLs
+  fIn.seek(offset)
+  if type(format)==int:
+    value = bytearray(source=fIn.read(format)).decode('latin-1')
+    if hdfBranch:
+      hdfBranch.attrs[key] = value.replace('\x00','')
+  else:
+    value = struct.unpack(format, fIn.read(struct.calcsize(format)))
+    if hdfBranch:
+      if len(value)==0:
+        hdfBranch.attrs[key] = value[0]
+      else:
+        hdfBranch.attrs[key] = value
+  return value
+
+def addData(format, hdfBranch, key, unit):
+  # helper function: add data to branch
+  data = fIn.read(struct.calcsize(format))
+  if len(data) < struct.calcsize(format):
+    return False
+  data = struct.unpack(format, data)
+  dset = hdfBranch.create_dataset(key, data=data)
+  dset.attrs['unit'] = unit
+  return True
+
+
+## SPECIFIC TO THIS CONVERTER: METADATA
+n    = addAttrs(0x2c,   'i',  None, '')[0]                  # size of datasets
+addAttrs(       0x2B50, 'i',  metadata, 'number test')      # number of test
+date = addAttrs(0x2E3C, '6i', None, '')                     # date and time
+metadata.attrs['date'] = datetime(date[2],date[1],date[0],date[3],date[4],date[5]).isoformat()
+addAttrs(       0x529C,   64, metadata, 'name method')      # name of method
+# 0x6A20-0x6BD8: unclear
+addAttrs(       0x7DE4,   36, metadata, 'name folder')      # name of folder
+addAttrs(       0x7E09,   22, metadata, 'displacement cell')# displacement cell
+addAttrs(       0x7E21,   22, metadata, 'load cell')        # load cell
+for i in range(7):                                          # 7 key-value pairs
+  addAttrs(0xA034+64*i,   64, metadata, [0xA674+32*i, 32])
+# 0x88A0: float : unclear
+addAttrs(       0xE29C,   36, metadata, 'file prefix')      # file-prefix
+addAttrs(       0xE450,   64, metadata, 'path')             # path
+
+## SPECIFIC TO THIS CONVERTER: DATA
+fIn.seek(0x10ea0)
+addData(str(n)+'d', fOut, 'time',         's')
+addData(str(n)+'f', fOut, 'displacement', 'mm')
+addData(str(n)+'f', fOut, 'force',        'N')
+# if more than 1 channels are stored:
+# - number of channels/sensors and its labeling are part of the machine configuration
+# - Machine configuration is stored in mdb database (MS standard jet) DB_UTM.mdb and there in table tblUTM
+#   -> use "mdb-export DB_UTM.mdb tblUTM > DB_UTM.csv" to convert it; Column "Machine1"
+# - this code: continue reading until failure
+idx = 0
+while True:
+  idx += 1
+  success = addData(str(n)+'f', fOut, 'data'+str(idx), '~')
+  if not success:  #end of file
+    break
+
+
+## COMMON PART FOR ALL CONVERTERS
+fIn.close()
+fOut.close()

--- a/cwl/PythonConverter/osc2hdf.py
+++ b/cwl/PythonConverter/osc2hdf.py
@@ -1,0 +1,1 @@
+/home/sbrinckm/FZJ/SourceCode/ReverseFileFormat/Converters/osc2hdf.py

--- a/cwl/PythonConverter/osc2hdf.py
+++ b/cwl/PythonConverter/osc2hdf.py
@@ -1,1 +1,99 @@
-/home/sbrinckm/FZJ/SourceCode/ReverseFileFormat/Converters/osc2hdf.py
+#!/usr/bin/python3
+"""
+convent osc file to hdf5 file (partial conversion)
+
+in_file:
+  label: EDAX binary file (.osc) with EBSD data
+  vendor: EDAX Ametek
+  software: old OIM versions
+out_file:
+  label: orix HDF5 file (pypi.org/project/orix)
+"""
+import math, h5py, sys, os, hashlib
+import numpy as np
+from diffpy.structure import Structure
+from orix.io import load, save                      #CWL requirement
+from orix.crystal_map import CrystalMap, PhaseList
+from orix.quaternion.rotation import Rotation
+
+convURI = 'https://raw.githubusercontent.com/NFDI4Chem/formaTAPIRest/main/cwl/osc2hdf.cwl'
+convVersion = '1.0'
+
+fileNameIn = sys.argv[1]
+fileNameOut= os.path.splitext(fileNameIn)[0]+'.hdf5'
+f = open(fileNameIn,"r")
+
+def find_subsequence(seq, subseq):
+  target = np.dot(subseq, subseq)
+  candidates = np.where(np.correlate(seq, subseq, mode='valid') == target)[0]
+  # some of the candidates entries may be false positives, double check
+  check = candidates[:, np.newaxis] + np.arange(len(subseq))
+  mask = np.all((np.take(seq, check) == subseq), axis=-1)
+  return candidates[mask]
+
+header = np.fromfile(f, dtype=np.uint32, count=8)
+n = header[6]   #number of data points
+#header[4]: numPixelX; header[5]: numPixelY
+numPhases = header[1]
+
+# find start position by using startByte-pattern
+bufferLength = int(math.pow(2,20))
+startBytes = np.array( [ int(i,16)  for i in ['B9', '0B', 'EF', 'FF', '02', '00', '00', '00'] ],dtype=np.uint8 )
+startPos = 0
+f.seek(startPos)
+startData = np.fromfile(f, dtype=np.uint8, count=bufferLength)
+# startPos += [x for x in xrange(len(startData)-len(startBytes)) if (startData[x:x+len(startBytes)] == startBytes).all() ][0]
+startPos += find_subsequence( startData, startBytes)[0]
+f.seek(startPos+8)
+
+# there are different osc file versions, one does have some count of data, the other proceeds with xStep and yStep (!=1)
+dn = np.double( np.fromfile(f,dtype=np.uint32, count=1))
+if round(((dn/4-2)/10)/n) != 1:
+  f.seek(startPos+8)
+stepSizeX = np.double(np.fromfile(f, dtype=np.float32, count=1))
+stepSizeY = np.double(np.fromfile(f, dtype=np.float32, count=1))
+
+data = np.reshape( np.double(np.fromfile(f, count=n*10, dtype=np.float32)) , (n,10) )
+phi1    = data[:,0].astype(np.float16)
+PHI     = data[:,1].astype(np.float16)
+phi2    = data[:,2].astype(np.float16)
+x       = data[:,3].astype(np.float32)
+y       = data[:,4].astype(np.float32)
+IQ      = data[:,5].astype(np.float16)
+CI      = data[:,6].astype(np.float16)
+phaseID = data[:,7].astype(np.float16) + 1
+SEMsignal= data[:,8].astype(np.float16) #SEMSignal
+fit     = data[:,9].astype(np.float16) #Fit
+
+numPhases = len(np.unique(phaseID))
+structures, names = [], []
+for i in range(numPhases):
+  structures.append(Structure(title='phase'+str(i)))
+  names.append('phase'+str(i))
+phaseList = PhaseList(names=names, point_groups=[None]*numPhases, structures=structures)
+
+#Assemble new data set
+eulerAngles = np.column_stack((phi1, PHI, phi2))
+rotations = Rotation.from_euler(eulerAngles)
+properties = {"iq":IQ, "ci":CI, 'sem':SEMsignal, 'fit':fit}
+ebsd2 = CrystalMap(rotations=rotations,
+                phase_id=phaseID,x=x, y=y,
+                phase_list=phaseList, prop=properties)
+
+#some corrections
+ebsd2.scan_unit = "um"
+save(filename=fileNameOut, object2write=ebsd2)
+f.close()
+
+#add converter information
+fIn   = open(fileNameIn,'br')
+fOut  = h5py.File(fileNameOut, 'a')
+converter = fOut.create_group("converter")
+converter.attrs['uri'] =     convURI
+converter.attrs['version'] = convVersion
+converter.attrs['original file name'] = fileNameIn
+md5Hash = hashlib.md5()
+md5Hash.update(fIn.read())
+converter.attrs['original md5-sum'] = md5Hash.hexdigest()
+fIn.close()
+fOut.close()

--- a/cwl/README_stub.md
+++ b/cwl/README_stub.md
@@ -1,10 +1,28 @@
-# Examples
-Put the yml code into default.yml and run it with
+# TAPIR | formaTAPIRest
+## How to use:
+1. create a YML file (e.g. "default.yml") with:
+    - conversion file "./test.cwl"
+    - input file "./EBSD.osc"
+    - output file "output.hdf5"
+    ```yml
+    cwl:tool: ./test.cwl
+    in_file:
+      class: File
+      path: ./input.dat
+    out_file: output.hdf5
+    ```
+1. run the conversion with
 ```sh
 cwl-runner default.yml
 ```
+If conversion uses docker, you should run the command with 'sudo'
 
-## Example: md5sum test
+## Add parameters into your .yml file
+```yml
+parameters: [--text, --tag]
+```
+
+### Example: md5sum test
 ```yml
 cwl:tool: ./md5sum.cwl
 in_file:
@@ -15,50 +33,18 @@ parameters: [--text, --tag]
 out_file: myOutput.txt
 ```
 
-## Example: png2jpg conversion
-```yml
-cwl:tool: ./png2jpg.cwl
-in_file:
-  class: File
-  format: http://edamontology.org/format_3603
-  path: kitten.png
-parameters: []
-out_file: myPic.jpg
-```
-
-## Example: mzXML2mzML conversion
-```yml
-cwl:tool: ./libremsconvert.cwl
-in_file:
-  class: File
-  format: edam:format_3654
-  path: RtmpIX4kGntest_write.mzXML
-parameters: []
-```
-
-## Example: RAW2mzML conversion
-```yml
-cwl:tool: ./msconvert.cwl
-in_file:
-  class: File
-  format: edam:format_3712
-  path: /tmp/nuts/fa3.RAW
-parameters: []
-```
-
-# Notes for developers of cwl-files
-
-## Rules
+## Notes for developers of cwl-files
+### Rules
 Files must have the following content, which is partly checked by produceTable.py:
 - a top-level label is required
 - author information (name and orcid-link)
 - input files require a label and optionally a doc-string
 - output files require EDAM classification and  a label
 
-## Examples for conversion
+### Examples for conversion
 - based on a command: png2jpg.cwl
 - multiple steps: zipped2bruker2jcamp.yml
 - use docker image: msconvert.yml
 - use python with specific dependencies (incl. pull python-docker): osc2hdf.yml
 
-# List of converters
+## List of converters

--- a/cwl/mvl2hdf.cwl
+++ b/cwl/mvl2hdf.cwl
@@ -1,0 +1,146 @@
+#!/usr/bin/env cwl-runner
+
+cwlVersion: v1.0
+class: CommandLineTool
+label: convert Doli .mvl to .hdf5 file (partial conversion of 15 metadata)
+
+baseCommand: ["sh","script.sh"]
+
+hints:
+  DockerRequirement:
+    dockerPull: python
+
+inputs:
+  in_file:
+    type: File
+    label: Doli binary file (.mvl) for tension-compression machine
+    doc: |-
+      vendor: Doli (www.doli.de)
+      software: Version 2.0
+  out_file:
+    type: string
+
+requirements:
+  InitialWorkDirRequirement:
+    listing:
+      # main shell script that starts pip and python
+      - entryname: script.sh
+        entry: |-
+          pip3 install -r requirements.txt
+          python convert.py
+      # pip install packages
+      - entryname: requirements.txt
+        entry: |-
+          h5py
+      # python script that does the work
+      - entryname: convert.py
+        entry: |-
+          import struct, sys, os, hashlib
+          import h5py                                    #CWL requirement
+          import numpy as np
+          from datetime import datetime
+
+          convURI = 'https://raw.githubusercontent.com/NFDI4Chem/formaTAPIRest/main/cwl/mvl2hdf.cwl'
+          convVersion = '1.0'
+
+          ## COMMON PART FOR ALL CONVERTERS
+          fileNameIn = '$(inputs.in_file.path)'
+          fileNameOut= '$(inputs.out_file)'
+          fIn   = open(fileNameIn,'br')
+          fOut  = h5py.File(fileNameOut, 'w')
+          metadata = fOut.create_group("metadata")
+          converter = fOut.create_group("converter")
+          converter.attrs['uri'] =     convURI
+          converter.attrs['version'] = convVersion
+          converter.attrs['original file name'] = fileNameIn
+          md5Hash = hashlib.md5()
+          md5Hash.update(fIn.read())
+          converter.attrs['original md5-sum'] = md5Hash.hexdigest()
+
+          def addAttrs(offset, format, hdfBranch, key):
+            # helper function: add attribute to branch
+            if type(key)==list:
+              fIn.seek(key[0])
+              key = bytearray(source=fIn.read(key[1])).decode('latin-1')
+              key = key.replace('\\x00','')   # ValueError: VLEN strings do not support embedded NULLs
+            fIn.seek(offset)
+            if type(format)==int:
+              value = bytearray(source=fIn.read(format)).decode('latin-1')
+              if hdfBranch:
+                hdfBranch.attrs[key] = value.replace('\\x00','')
+            else:
+              value = struct.unpack(format, fIn.read(struct.calcsize(format)))
+              if hdfBranch:
+                if len(value)==0:
+                  hdfBranch.attrs[key] = value[0]
+                else:
+                  hdfBranch.attrs[key] = value
+            return value
+
+          def addData(format, hdfBranch, key, unit):
+            # helper function: add data to branch
+            data = fIn.read(struct.calcsize(format))
+            if len(data) < struct.calcsize(format):
+              return False
+            data = struct.unpack(format, data)
+            dset = hdfBranch.create_dataset(key, data=data)
+            dset.attrs['unit'] = unit
+            return True
+
+
+          ## SPECIFIC TO THIS CONVERTER: METADATA
+          n    = addAttrs(0x2c,   'i',  None, '')[0]                  # size of datasets
+          addAttrs(       0x2B50, 'i',  metadata, 'number test')      # number of test
+          date = addAttrs(0x2E3C, '6i', None, '')                     # date and time
+          metadata.attrs['date'] = datetime(date[2],date[1],date[0],date[3],date[4],date[5]).isoformat()
+          addAttrs(       0x529C,   64, metadata, 'name method')      # name of method
+          # 0x6A20-0x6BD8: unclear
+          addAttrs(       0x7DE4,   36, metadata, 'name folder')      # name of folder
+          addAttrs(       0x7E09,   22, metadata, 'displacement cell')# displacement cell
+          addAttrs(       0x7E21,   22, metadata, 'load cell')        # load cell
+          for i in range(7):                                          # 7 key-value pairs
+            addAttrs(0xA034+64*i,   64, metadata, [0xA674+32*i, 32])
+          # 0x88A0: float : unclear
+          addAttrs(       0xE29C,   36, metadata, 'file prefix')      # file-prefix
+          addAttrs(       0xE450,   64, metadata, 'path')             # path
+
+          ## SPECIFIC TO THIS CONVERTER: DATA
+          fIn.seek(0x10ea0)
+          addData(str(n)+'d', fOut, 'time',         's')
+          addData(str(n)+'f', fOut, 'displacement', 'mm')
+          addData(str(n)+'f', fOut, 'force',        'N')
+          # last data
+          # - unclear where existence and unit of this are stored
+          # - this code: continue reading until failure
+          idx = 0
+          while True:
+            idx += 1
+            success = addData(str(n)+'f', fOut, 'data'+str(idx), '~')
+            if not success:  #end of file
+              break
+
+
+          ## COMMON PART FOR ALL CONVERTERS
+          fIn.close()
+          fOut.close()
+
+
+outputs:
+  outfile:
+    type: File
+    label: custom HDF5 with k-series as well as metadata and converter groups
+    format: edam:format_3590
+    outputBinding:
+      glob: $(inputs.out_file)
+
+s:author:
+  - class: s:Person
+    s:identifier: https://orcid.org/0000-0003-0930-082X
+    s:name: Steffen Brinckmann
+
+$namespaces:
+  s: https://schema.org/
+  edam: http://edamontology.org/
+$schemas:
+  - https://schema.org/version/latest/schemaorg-current-http.rdf
+  - http://edamontology.org/EDAM_1.18.owl

--- a/cwl/mvl2hdf.cwl
+++ b/cwl/mvl2hdf.cwl
@@ -16,7 +16,7 @@ inputs:
     label: Doli binary file (.mvl) for tension-compression machine
     doc: |-
       vendor: Doli (www.doli.de)
-      software: Version 2.0
+      software: Test&Motion (Software for Universal Test Machines for Windows) Version 4.1
   out_file:
     type: string
 
@@ -109,8 +109,10 @@ requirements:
           addData(str(n)+'d', fOut, 'time',         's')
           addData(str(n)+'f', fOut, 'displacement', 'mm')
           addData(str(n)+'f', fOut, 'force',        'N')
-          # last data
-          # - unclear where existence and unit of this are stored
+          # if more than 1 channels are stored:
+          # - number of channels/sensors and its labeling are part of the machine configuration
+          # - Machine configuration is stored in mdb database (MS standard jet) DB_UTM.mdb and there in table tblUTM
+          #   -> use "mdb-export DB_UTM.mdb tblUTM > DB_UTM.csv" to convert it; Column "Machine1"
           # - this code: continue reading until failure
           idx = 0
           while True:

--- a/cwl/translatePY2CWL.py
+++ b/cwl/translatePY2CWL.py
@@ -1,0 +1,104 @@
+#!/usr/bin/python3
+import os
+
+for pyFileName in os.listdir('PythonConverter'):
+  print('\nUse',pyFileName)
+  pyFile = open('PythonConverter/'+pyFileName,'r')
+  cwlFile = open(pyFileName[:-2]+'cwl','w')
+
+  cwlFile.write('#!/usr/bin/env cwl-runner'+'\n'*2)
+  cwlFile.write('cwlVersion: v1.0'+'\n')
+  cwlFile.write('class: CommandLineTool'+'\n')
+
+  #HEADER
+  _ = pyFile.readline()
+  if pyFile.readline().strip() != '"""':
+    print("Error reading head of python file 1")
+    break
+  label = pyFile.readline()
+  cwlFile.write('label: '+label+'\n')
+  cwlFile.write('baseCommand: ["sh","script.sh"]'+'\n'*2)
+  cwlFile.write('hints:'+'\n')
+  cwlFile.write('  DockerRequirement:'+'\n')
+  cwlFile.write('    dockerPull: python'+'\n'*2)
+  cwlFile.write('inputs:'+'\n')
+  cwlFile.write('  in_file:'+'\n')
+  cwlFile.write('    type: File'+'\n')
+  _ = pyFile.readline()
+  if pyFile.readline().strip() != 'in_file:':
+    print("Error reading head of python file 2")
+    break
+  label = pyFile.readline()
+  cwlFile.write('  '+label)
+  cwlFile.write('    doc: |-'+'\n')
+  vendor = pyFile.readline()
+  cwlFile.write('    '+vendor)
+  software = pyFile.readline()
+  cwlFile.write('    '+software)
+  cwlFile.write('  out_file:'+'\n')
+  cwlFile.write('    type: string'+'\n'*2)
+  cwlFile.write('requirements:'+'\n')
+  cwlFile.write('  InitialWorkDirRequirement:'+'\n')
+  cwlFile.write('    listing:'+'\n')
+  cwlFile.write('      # main shell script that starts pip and python'+'\n')
+  cwlFile.write('      - entryname: script.sh'+'\n')
+  cwlFile.write('        entry: |-'+'\n')
+  cwlFile.write('          pip3 install -r requirements.txt'+'\n')
+  cwlFile.write('          python convert.py'+'\n')
+  cwlFile.write('      # pip install packages'+'\n')
+  cwlFile.write('      - entryname: requirements.txt'+'\n')
+  cwlFile.write('        entry: |-'+'\n')
+  if pyFile.readline().strip() != 'out_file:':
+    print("Error reading head of python file 3")
+    break
+  labelOut = pyFile.readline()  #read now, use later
+  # get requirements
+  requirements = []
+  for line in pyFile:
+    if '#CWL requirement' in line:
+      requirements.append(line.split()[1].split('.')[0])
+  cwlFile.write('          '+' '.join(requirements)+'\n')
+  cwlFile.write('      # python script that does the work'+'\n')
+  cwlFile.write('      - entryname: convert.py'+'\n')
+  cwlFile.write('        entry: |-'+'\n')
+
+  #MAIN PART: parse file
+  pyFile.seek(0)
+  for i in range(11):
+    pyFile.readline()
+  while True:
+    line = pyFile.readline()
+    if line.startswith('fileNameIn ='):
+      line = "fileNameIn = '$(inputs.in_file.path)'\n"
+    if line.startswith('fileNameOut='):
+      line = "fileNameOut= '$(inputs.out_file)'\n"
+    line = line.replace('\\x00','\\\\x00')
+    if len(line)==0:
+      break
+    if len(line)>1:
+      cwlFile.write('          '+line)
+    else:
+      cwlFile.write('\n')    #keep empty lines empty
+
+  #FOOTER
+  cwlFile.write('\n'*2)
+  cwlFile.write('outputs:'+'\n')
+  cwlFile.write('  outfile:'+'\n')
+  cwlFile.write('    type: File'+'\n')
+  cwlFile.write('  '+labelOut)
+  cwlFile.write('    format: edam:format_3590'+'\n')
+  cwlFile.write('    outputBinding:'+'\n')
+  cwlFile.write('      glob: $(inputs.out_file)'+'\n'*2)
+  cwlFile.write('s:author:'+'\n')
+  cwlFile.write('  - class: s:Person'+'\n')
+  cwlFile.write('    s:identifier: https://orcid.org/0000-0003-0930-082X'+'\n')
+  cwlFile.write('    s:name: Steffen Brinckmann'+'\n'*2)
+  cwlFile.write('$namespaces:'+'\n')
+  cwlFile.write('  s: https://schema.org/'+'\n')
+  cwlFile.write('  edam: http://edamontology.org/'+'\n')
+  cwlFile.write('$schemas:'+'\n')
+  cwlFile.write('  - https://schema.org/version/latest/schemaorg-current-http.rdf'+'\n')
+  cwlFile.write('  - http://edamontology.org/EDAM_1.18.owl'+'\n')
+
+  pyFile.close()
+  cwlFile.close()


### PR DESCRIPTION
Hey,
I wrote a script (with two examples) of how to convert .py files into .cwl files [Some structure elements of the python file have to remain]. This allows me to write and test with python and then generate the cwl files.

With mvl2hdf.cwl there is a newly reverse engineered format.
- I always include information on the converter (URL, version) and the original file (name and md5sum) to allow referencing the conversion and the input.

I also simplified the Readme_stub.md to only have a generic example and the rest follows from that example.

Pull as you see fit and usefull. If you are only interested in the final cwl files and not the changes to Readme, etc. also fine. I would then adopt my branch to stay consistent and move the non-desired parts into another project.
Best, Steffen